### PR TITLE
Change default runner of i586 to qemu-user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 ## [Unreleased]
 
+- Change default runner of i586 to qemu-user. ([#5](https://github.com/taiki-e/setup-cross-toolchain/pull/5))
+
 ## [1.1.1] - 2022-02-23
 
 - Fix the `DOCTEST_XCOMPILE` environment variable.

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ jobs:
 | `armv5te-unknown-linux-gnueabi` | ubuntu-latest/ubuntu-20.04 [1], ubuntu-18.04 [2] | qemu-user (default) |
 | `armv7-unknown-linux-gnueabi` | ubuntu-latest/ubuntu-20.04 [1], ubuntu-18.04 [2] | qemu-user (default) |
 | `armv7-unknown-linux-gnueabihf` | ubuntu-latest/ubuntu-20.04 [1], ubuntu-18.04 [2] | qemu-user (default) |
-| `i586-unknown-linux-gnu` | ubuntu-latest/ubuntu-20.04 [1], ubuntu-18.04 [2] | native (default), qemu-user |
+| `i586-unknown-linux-gnu` | ubuntu-latest/ubuntu-20.04 [1], ubuntu-18.04 [2] | qemu-user (default), native |
 | `i686-unknown-linux-gnu` | ubuntu-latest/ubuntu-20.04 [1], ubuntu-18.04 [2] | native (default), qemu-user |
 | `mips-unknown-linux-gnu` | <!-- ubuntu-latest/ubuntu-20.04 [1],--> ubuntu-18.04 [2] | qemu-user (default) |
 | `mips64-unknown-linux-gnuabi64` | <!-- ubuntu-latest/ubuntu-20.04 [1],--> ubuntu-18.04 [2] | qemu-user (default) |

--- a/main.sh
+++ b/main.sh
@@ -127,10 +127,11 @@ case "${host}" in
                     '')
                         case "${target}" in
                             # On x86, qemu-user is not used by default.
-                            x86_64-* | i*86-*) ;;
+                            x86_64-* | i686-*) ;;
                             *) use_qemu='1' ;;
                         esac
                         ;;
+                    native) ;;
                     qemu-user) use_qemu='1' ;;
                     *) bail "unrecognized runner '${runner}'" ;;
                 esac


### PR DESCRIPTION
I ran into a case where the native runner did not seem to work well.

https://github.com/taiki-e/portable-atomic/runs/5308795079?check_suite_focus=true
https://github.com/taiki-e/portable-atomic/actions/runs/1887458288/attempts/1