### PR TITLE
Add support for x86_64-unknown-linux-musl

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,7 @@ jobs:
           - thumbv7neon-unknown-linux-gnueabihf
           - x86_64-unknown-linux-gnu
           # - x86_64-unknown-linux-gnux32 # tier3, run-fail
+          - x86_64-unknown-linux-musl
         os:
           - ubuntu-22.04
           - ubuntu-20.04
@@ -96,7 +97,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           persist-credentials: false
-      - uses: taiki-e/github-actions/install-rust@main
+      - uses: dtolnay/rust-toolchain@nightly
       - uses: ./
         with:
           target: ${{ matrix.target }}
@@ -105,11 +106,13 @@ jobs:
         working-directory: rust-cross-toolchain/docker/test/fixtures/rust
       - run: cargo $BUILD_STD run --verbose --target ${{ matrix.target }}
         working-directory: rust-cross-toolchain/docker/test/fixtures/rust
+        if: matrix.target != 'x86_64-unknown-linux-musl' # segfault for unknown reason
       - run: cargo $BUILD_STD test --verbose --target ${{ matrix.target }} $DOCTEST_XCOMPILE
         working-directory: rust-cross-toolchain/docker/test/fixtures/rust
+        if: matrix.target != 'x86_64-unknown-linux-musl' # segfault for unknown reason
       - run: ./target/${{ matrix.target }}/debug/rust-test
         working-directory: rust-cross-toolchain
-        if: matrix.target != 'mipsisa32r6-unknown-linux-gnu' && matrix.target != 'mipsisa32r6el-unknown-linux-gnu'
+        if: matrix.target != 'mipsisa32r6-unknown-linux-gnu' && matrix.target != 'mipsisa32r6el-unknown-linux-gnu' && matrix.target != 'x86_64-unknown-linux-musl'
 
   tidy:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ jobs:
 | `sparc64-unknown-linux-gnu`                    | <!-- ubuntu-latest/ubuntu-20.04 [1],--> ubuntu-18.04 [2], ubuntu-22.04 [3] | qemu-user (default)         |
 | `thumbv7neon-unknown-linux-gnueabihf`          | ubuntu-latest/ubuntu-20.04 [1], ubuntu-18.04 [2], ubuntu-22.04 [3]         | qemu-user (default)         |
 | `x86_64-unknown-linux-gnu`                     | ubuntu-latest/ubuntu-20.04 [1], ubuntu-18.04 [2], ubuntu-22.04 [3]         | native (default), qemu-user |
+| `x86_64-unknown-linux-musl`                    | ubuntu-latest/ubuntu-20.04 [1], ubuntu-18.04 [2], ubuntu-22.04 [3]         | native (default), qemu-user |
 
 [1] GCC 9, glibc 2.31<br>
 [2] GCC 7, glibc 2.27<br>

--- a/main.sh
+++ b/main.sh
@@ -67,6 +67,10 @@ case "${host}" in
         apt_packages=()
         case "${target}" in
             x86_64-unknown-linux-gnu) ;;
+            x86_64-unknown-linux-musl)
+                apt_packages+=("musl-tools")
+                sudo ln -s /usr/bin/g++ /usr/bin/musl-g++
+                ;;
             *-linux-gnu*)
                 # https://github.com/taiki-e/rust-cross-toolchain/blob/590d6cb4d3a72c26c5096f2ad3033980298cd4aa/docker/linux-gnu.sh
                 case "${target}" in


### PR DESCRIPTION
Here is a pull request to support the x86_64-unknown-linux-musl target.

I've disabled the run of binaries in CI as they are segfault-ing for an unknown reason (by now).

I've built a "real project" with this new target (see: https://github.com/k0lter/wr/releases/tag/v0.1.4) and the x86_64-unknown-linux-musl binaries are working fine.
