### PR TITLE
Support linux-musl targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,32 @@ jobs:
           - x86_64-unknown-linux-gnu
           # - x86_64-unknown-linux-gnux32 # tier3, run-fail
 
+          # Linux (musl)
+          # rustup target list | grep -e '-linux-musl'
+          # rustc --print target-list | grep -e '-linux-musl'
+          - aarch64-unknown-linux-musl
+          - arm-unknown-linux-musleabi
+          - arm-unknown-linux-musleabihf
+          - armv5te-unknown-linux-musleabi
+          - armv7-unknown-linux-musleabi
+          - armv7-unknown-linux-musleabihf
+          # - hexagon-unknown-linux-musl # tier3
+          - i586-unknown-linux-musl
+          - i686-unknown-linux-musl
+          - mips-unknown-linux-musl
+          # - mips64-openwrt-linux-musl # tier3
+          - mips64-unknown-linux-muslabi64
+          - mips64el-unknown-linux-muslabi64
+          - mipsel-unknown-linux-musl
+          # - powerpc-unknown-linux-musl # tier3
+          # - powerpc64-unknown-linux-musl # tier3
+          # - powerpc64le-unknown-linux-musl # tier3
+          # - riscv32gc-unknown-linux-musl # tier3
+          # - riscv64gc-unknown-linux-musl # tier3
+          # - s390x-unknown-linux-musl # tier3
+          # - thumbv7neon-unknown-linux-musleabihf # tier3
+          - x86_64-unknown-linux-musl
+
           # FreeBSD
           # rustup target list | grep -e '-freebsd'
           # rustc --print target-list | grep -e '-freebsd'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,26 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 ## [Unreleased]
 
+- Support linux-musl targets ([#12](https://github.com/taiki-e/setup-cross-toolchain-action/pull/12))
+
+  All tier 1 or 2 linux-musl targets are now supported:
+
+  - aarch64-unknown-linux-musl
+  - arm-unknown-linux-musleabi
+  - arm-unknown-linux-musleabihf
+  - armv5te-unknown-linux-musleabi
+  - armv7-unknown-linux-musleabi
+  - armv7-unknown-linux-musleabihf
+  - i586-unknown-linux-musl
+  - i686-unknown-linux-musl
+  - mips-unknown-linux-musl
+  - mips64-unknown-linux-muslabi64
+  - mips64el-unknown-linux-muslabi64
+  - mipsel-unknown-linux-musl
+  - x86_64-unknown-linux-musl
+
+  (Other linux-musl targets supported by [rust-cross-toolchain](https://github.com/taiki-e/rust-cross-toolchain#linux-musl) also may work, although this action's CI has not tested them.)
+
 - Set `PKG_CONFIG_ALLOW_CROSS=1` environment variable when the target triple and host triple is different.
 
 ## [1.9.0] - 2023-07-09

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ GitHub Action for setup toolchains for cross compilation and cross testing for R
   - [Example workflow: Doctest](#example-workflow-doctest)
 - [Platform Support](#platform-support)
   - [Linux (GNU)](#linux-gnu)
+  - [Linux (musl)](#linux-musl)
   - [FreeBSD](#freebsd)
   - [NetBSD](#netbsd)
   - [Windows (GNU)](#windows-gnu)
@@ -168,6 +169,48 @@ jobs:
 [6] binfmt doesn't work<br>
 [7] GCC 7, glibc 2.25<br>
 [8] [Since nightly-2023-07-05](https://github.com/rust-lang/compiler-team/issues/648), mips{,el}-unknown-linux-gnu requires release mode for building std<br>
+
+### Linux (musl)
+
+| libc | GCC | C++ | test |
+| ---- | --- | --- | ---- |
+| musl 1.2.3 / 1.1.24 [1] | 9.4.0 | ? (libstdc++) | ✓ |
+
+[1]: [1.2 on Rust 1.71+](https://github.com/rust-lang/rust/pull/107129), otherwise 1.1. 1.1 toolchain is with a patch that fixes CVE-2020-28928.
+
+**Supported targets**:
+
+| target | host | runner | note |
+| ------ | ---- | ------ | ---- |
+| `aarch64-unknown-linux-musl`           | x86_64 linux | qemu-user (default)         |       |
+| `arm-unknown-linux-musleabi`           | x86_64 linux | qemu-user (default)         |       |
+| `arm-unknown-linux-musleabihf`         | x86_64 linux | qemu-user (default)         |       |
+| `armv5te-unknown-linux-musleabi`       | x86_64 linux | qemu-user (default)         |       |
+| `armv7-unknown-linux-musleabi`         | x86_64 linux | qemu-user (default)         |       |
+| `armv7-unknown-linux-musleabihf`       | x86_64 linux | qemu-user (default)         |       |
+| `i586-unknown-linux-musl`              | x86_64 linux | qemu-user (default), native |       |
+| `i686-unknown-linux-musl`              | x86_64 linux | native (default), qemu-user |       |
+| `mips-unknown-linux-musl`              | x86_64 linux | qemu-user (default)         |       |
+| `mips64-unknown-linux-muslabi64`       | x86_64 linux | qemu-user (default)         |       |
+| `mips64el-unknown-linux-muslabi64`     | x86_64 linux | qemu-user (default)         |       |
+| `mipsel-unknown-linux-musl`            | x86_64 linux | qemu-user (default)         |       |
+| `x86_64-unknown-linux-musl`            | x86_64 linux | native (default), qemu-user |       |
+
+(Other linux-musl targets supported by [rust-cross-toolchain](https://github.com/taiki-e/rust-cross-toolchain#linux-musl) also may work, although this action's CI has not tested them.)
+
+`mips{,el}-unknown-linux-musl` are dynamically linked by default. To compile in the same way as other musl targets, you need to set `-C target-feature=+crt-static` and `-C link-self-contained=yes`. For example:
+
+```yaml
+- uses: taiki-e/setup-cross-toolchain-action@v1
+  with:
+    target: mips-unknown-linux-musl
+- run: cargo build
+  env:
+    # `-C target-feature=+crt-static` to enable static linking.
+    # `-C link-self-contained=yes` to link with libraries and objects shipped with Rust.
+    # `${{ env.RUSTFLAGS }}` is needed if you want to inherit existing rustflags.
+    RUSTFLAGS: ${{ env.RUSTFLAGS }} -C target-feature=+crt-static -C link-self-contained=yes
+```
 
 ### FreeBSD
 

--- a/main.sh
+++ b/main.sh
@@ -53,6 +53,8 @@ target_lower="${target_lower//./_}"
 target_upper="$(tr '[:lower:]' '[:upper:]' <<<"${target_lower}")"
 host=$(rustc -Vv | grep 'host: ' | cut -c 7-)
 rustc_version=$(rustc -Vv | grep 'release: ' | cut -c 10-)
+rustc_minor_version="${rustc_version#*.}"
+rustc_minor_version="${rustc_minor_version%%.*}"
 rustup_target_list=$(rustup target list | sed 's/ .*//g')
 
 install_apt_packages() {
@@ -157,6 +159,15 @@ setup_linux_host() {
     apt_packages=()
     case "${target}" in
         x86_64-unknown-linux-gnu) ;;
+        *-linux-musl*)
+            # https://github.com/rust-lang/rust/pull/107129
+            if [[ "${rustc_minor_version}" -lt 71 ]]; then
+                sys_version=1.1
+            else
+                sys_version=1.2
+            fi
+            install_rust_cross_toolchain
+            ;;
         *-linux-gnu*)
             # https://github.com/taiki-e/rust-cross-toolchain/blob/590d6cb4d3a72c26c5096f2ad3033980298cd4aa/docker/linux-gnu.sh
             case "${target}" in


### PR DESCRIPTION
All tier 1 or 2 linux-musl targets are now supported:

- aarch64-unknown-linux-musl
- arm-unknown-linux-musleabi
- arm-unknown-linux-musleabihf
- armv5te-unknown-linux-musleabi
- armv7-unknown-linux-musleabi
- armv7-unknown-linux-musleabihf
- i586-unknown-linux-musl
- i686-unknown-linux-musl
- mips-unknown-linux-musl
- mips64-unknown-linux-muslabi64
- mips64el-unknown-linux-muslabi64
- mipsel-unknown-linux-musl
- x86_64-unknown-linux-musl

(Other linux-musl targets supported by [rust-cross-toolchain](https://github.com/taiki-e/rust-cross-toolchain#linux-musl) also may work, although this action's CI has not tested them.)

Closes #6