### PR TITLE
Support windows-gnullvm

### DIFF
--- a/.github/.cspell/organization-dictionary.txt
+++ b/.github/.cspell/organization-dictionary.txt
@@ -151,6 +151,7 @@ endianness
 esac
 euxo
 gsub
+libc
 moreutils
 msys
 noninteractive

--- a/.github/.cspell/project-dictionary.txt
+++ b/.github/.cspell/project-dictionary.txt
@@ -5,7 +5,6 @@ CXXSTDLIB
 devel
 endgroup
 haswell
-libc
 libclang
 libstdc
 Loongson
@@ -19,5 +18,6 @@ WINEBOOT
 winehq
 WINEPATH
 WINEPREFIX
+wineserver
 Zbuild
 Zdoctest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,6 @@ env:
   CARGO_NET_GIT_FETCH_WITH_CLI: true
   CARGO_NET_RETRY: 10
   CARGO_TERM_COLOR: always
-  QEMU_STRACE: 1
   RUST_BACKTRACE: 1
   RUSTDOCFLAGS: -D warnings
   RUSTFLAGS: -D warnings
@@ -184,7 +183,7 @@ jobs:
           # - { target: thumbv7a-pc-windows-msvc, os: windows-latest } # tier3
           - { target: x86_64-pc-windows-msvc, os: windows-latest }
 
-          # Windows (GNU)
+          # Windows (MinGW)
           # rustup target list | grep -e '-pc-windows-gnu'
           # rustc --print target-list | grep -e '-pc-windows-gnu'
           # Windows host:
@@ -194,13 +193,13 @@ jobs:
             os: windows-latest
           # Linux host:
           # - target: i686-pc-windows-gnu
-          #   os: ubuntu-22.04
           - target: x86_64-pc-windows-gnu
-            os: ubuntu-22.04
           - target: x86_64-pc-windows-gnu
             runner: wine@7.13
           - target: x86_64-pc-windows-gnu
             runner: wine@7.0.1
+          - target: x86_64-pc-windows-gnullvm
+          - target: aarch64-pc-windows-gnullvm
         # prettier-ignore
         exclude:
           # Segmentation fault on ubuntu 20.04: https://github.com/taiki-e/setup-cross-toolchain-action/issues/1
@@ -220,6 +219,8 @@ jobs:
           persist-credentials: false
       - name: Install Rust
         run: rustup toolchain add nightly --no-self-update && rustup default nightly
+      - run: echo "QEMU_STRACE=1" >>"${GITHUB_ENV}"
+        if: matrix.target != 'aarch64-pc-windows-gnullvm'
       - uses: ./
         with:
           target: ${{ matrix.target }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 ## [Unreleased]
 
+- Support windows-gnullvm targets on Linux host.
+
+  - aarch64-pc-windows-gnullvm
+  - x86_64-pc-windows-gnullvm
+
+  Running tests is supported on both targets.
+
 ## [1.14.0] - 2023-07-28
 
 - Support Windows targets on Windows host.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ GitHub Action for setup toolchains for cross compilation and cross testing for R
   - [FreeBSD](#freebsd)
   - [NetBSD](#netbsd)
   - [WASI](#wasi)
-  - [Windows (GNU)](#windows-gnu)
+  - [Windows (MinGW)](#windows-mingw)
+  - [Windows (LLVM MinGW)](#windows-llvm-mingw)
   - [Windows (MSVC)](#windows-msvc)
   - [macOS](#macos)
 - [Related Projects](#related-projects)
@@ -367,23 +368,21 @@ Only specifying a major version is supported.
 
 ### WASI
 
-| C++ | test |
-| --- | ---- |
-| ? (libc++) | ✓ |
+| libc | Clang | C++ | test |
+| ---- | ----- | --- | ---- |
+| wasi-sdk 20 (wasi-libc 1dfe5c3) | 16.0.0 | ? (libc++) | ✓ |
+
+<!--
+clang version and wasi-libc hash can be found here: https://github.com/taiki-e/rust-cross-toolchain#wasi
+-->
 
 **Supported targets**:
 
 | target | host | runner | note |
 | ------ | ---- | ------ | ---- |
-| `wasm32-wasi` | x86_64 Linux [1] | wasmtime |  |
+| `wasm32-wasi` | x86_64 Linux | wasmtime |  |
 
-<!--
-clang version and wasi-libc hash can be found here: https://github.com/WebAssembly/wasi-sdk/tree/wasi-sdk-16/src
--->
-
-[1] clang 14, wasi-sdk 16 (wasi-libc 30094b6)<br>
-
-### Windows (GNU)
+### Windows (MinGW)
 
 | C++ | test |
 | --- | ---- |
@@ -412,6 +411,19 @@ You can select/pin the version by using `@` syntax in `runner` input option. For
     target: x86_64-pc-windows-gnu
     runner: wine@7.13
 ```
+
+### Windows (LLVM MinGW)
+
+| libc | Clang | C++ | test |
+| ---- | ----- | --- | ---- |
+| Mingw-w64 b190082 | 16.0.6 | ✓ (libc++) | ✓ |
+
+**Supported targets**:
+
+| target | host | runner | note |
+| ------ | ---- | ------ | ---- |
+| `aarch64-pc-windows-gnullvm` | Ubuntu (22.04) | wine |  |
+| `x86_64-pc-windows-gnullvm` | Ubuntu (22.04) | wine |  |
 
 ### Windows (MSVC)
 

--- a/tools/ci/test.sh
+++ b/tools/ci/test.sh
@@ -26,7 +26,7 @@ esac
 skip_run() {
     case "${target}" in
         # x86_64h-apple-darwin is also x86_64 but build-only due to the CPU of GitHub-provided macOS runners is older than haswell.
-        *-freebsd* | *-netbsd* | x86_64h-apple-darwin | aarch64*-darwin* | aarch64*-windows*) return 0 ;;
+        *-freebsd* | *-netbsd* | x86_64h-apple-darwin | aarch64*-darwin* | aarch64*-windows-msvc) return 0 ;;
         *) return 1 ;;
     esac
 }


### PR DESCRIPTION
Support windows-gnullvm targets on Linux host.

- aarch64-pc-windows-gnullvm
- x86_64-pc-windows-gnullvm

Running tests is supported on both targets.