### PR TITLE
feat: add `package` input to install packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 ## [Unreleased]
 
+- Add `packages` input to install additional packages that can be build against. ([#23](https://github.com/taiki-e/setup-cross-toolchain-action/pull/23))
+
 ## [1.23.1] - 2024-08-11
 
 - Fix build issue with 32-bit android targets on recent nightly due to [upstream change](https://github.com/rust-lang/rust/pull/120593). ([2068a2d](https://github.com/taiki-e/setup-cross-toolchain-action/commit/2068a2dd8a68fdcf653e4fa1312cbe24475ff07b))

--- a/README.md
+++ b/README.md
@@ -32,10 +32,11 @@ GitHub Action for setup toolchains for cross compilation and cross testing for R
 
 ### Inputs
 
-| Name     | Required | Description   | Type   | Default        |
-|----------|:--------:|---------------|--------|----------------|
-| target   | **true** | Target triple | String |                |
-| runner   | false    | Test runner   | String |                |
+| Name     | Required | Description         | Type   | Default |
+|----------|:--------:|---------------------|--------|---------|
+| target   | **true** | Target triple       | String |         |
+| packages | false    | Packages to install | String |         |
+| runner   | false    | Test runner         | String |         |
 
 ### Example workflow: Basic usage
 
@@ -59,6 +60,27 @@ jobs:
       # You can also run the cross-compiled binaries directly (via binfmt).
       - run: ./target/aarch64-unknown-linux-gnu/debug/my-app
 ```
+
+### Example workflow: Installing additional packages
+
+```yaml
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust
+        run: rustup update stable
+      - name: Install cross-compilation tools
+        uses: taiki-e/setup-cross-toolchain-action@v1
+        with:
+          target: aarch64-unknown-linux-gnu
+          packages: libgbm-dev libxkbcommon-dev libinput-dev libudev-dev libseat-dev
+      - run: cargo build
+```
+
+> [!NOTE]
+> The list of packages can be space seperated, comma seperated or newline seperated.
 
 ### Example workflow: Multiple targets
 

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ inputs:
     description: Target name
     required: true
   packages:
-    description: Packages
+    description: Packages to install
     required: false
   runner:
     description: Test runner

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,9 @@ inputs:
   target:
     description: Target name
     required: true
+  packages:
+    description: Packages
+    required: false
   runner:
     description: Test runner
     required: false
@@ -25,6 +28,7 @@ runs:
       shell: bash
       env:
         INPUT_TARGET: ${{ inputs.target }}
+        INPUT_PACKAGES: ${{ inputs.packages }}
         INPUT_RUNNER: ${{ inputs.runner }}
         INPUT_QEMU: ${{ inputs.qemu }}
         INPUT_WINE: ${{ inputs.wine }}

--- a/main.sh
+++ b/main.sh
@@ -356,11 +356,6 @@ register_binfmt() {
 
 setup_linux_host() {
     apt_packages=()
-    while read -rd,; do
-        if [[ -n "${REPLY}" ]]; then
-            apt_packages+=("${REPLY}")
-        fi
-    done <<<"${packages//[$' \t\n']/,},"
     if [[ "${host}" == "${target}" ]]; then
         # TODO: can we reduce the setup time by providing an option to skip installing packages for C++?
         # TODO: other lang? https://packages.ubuntu.com/search?lang=en&suite=jammy&arch=any&searchon=names&keywords=12-aarch64-linux-gnu
@@ -554,6 +549,7 @@ EOF
                         wine_root=/opt/wine-arm64
                         wine_exe="${wine_root}"/bin/wine
                         qemu_arch=aarch64
+                        _sudo dpkg --add-architecture arm64
                         if [[ -n "${INPUT_WINE:-}" ]]; then
                             warn "specifying Wine version for aarch64 windows is not yet supported"
                         fi
@@ -769,6 +765,35 @@ EOF
         install_qemu
         register_binfmt qemu-user
     fi
+
+    case "${target}" in
+        aarch64* | arm64*) dpkg_arch=arm64 ;;
+        arm* | thumb*) dpkg_arch=arm ;;
+        i?86-*) dpkg_arch=i386 ;;
+        hexagon-*) dpkg_arch=hexagon ;;
+        loongarch64-*) dpkg_arch=loongarch64 ;;
+        m68k-*) dpkg_arch=m68k ;;
+        mips-* | mipsel-*) dpkg_arch="${target%%-*}" ;;
+        mips64-* | mips64el-*) dpkg_arch="${target%%-*}" ;;
+        mipsisa32r6-* | mipsisa32r6el-*) dpkg_arch="${target%%-*}" ;;
+        mipsisa64r6-* | mipsisa64r6el-*) dpkg_arch="${target%%-*}" ;;
+        powerpc-*spe) dpkg_arch=ppc ;;
+        powerpc-*) dpkg_arch=ppc ;;
+        powerpc64-* | powerpc64le-*) dpkg_arch="${target%%-*}" ;;
+        riscv32*) dpkg_arch=riscv32 ;;
+        riscv64*) dpkg_arch=riscv64 ;;
+        s390x-*) dpkg_arch=s390x ;;
+        sparc-*) dpkg_arch=sparc ;;
+        sparc64-* | sparcv9-*) dpkg_arch=sparc64 ;;
+        x86_64*) dpkg_arch=amd64 ;;
+        *) bail "unrecognized target '${target}'" ;;
+    esac
+
+    while read -rd,; do
+    if [[ -n "${REPLY}" ]]; then
+        apt_packages+=("${REPLY}:${dpkg_arch}")
+    fi
+    done <<<"${packages//[$' \t\n']/,},"
 
     install_apt_packages
 

--- a/main.sh
+++ b/main.sh
@@ -356,7 +356,11 @@ register_binfmt() {
 
 setup_linux_host() {
     apt_packages=()
-    IFS=" " read -r -a apt_packages <<<"${packages}"
+    while read -rd,; do
+        if [[ -n "${REPLY}" ]]; then
+            apt_packages+=("${REPLY}")
+        fi
+    done <<<"${packages// /,},"
     if [[ "${host}" == "${target}" ]]; then
         # TODO: can we reduce the setup time by providing an option to skip installing packages for C++?
         # TODO: other lang? https://packages.ubuntu.com/search?lang=en&suite=jammy&arch=any&searchon=names&keywords=12-aarch64-linux-gnu

--- a/main.sh
+++ b/main.sh
@@ -53,6 +53,7 @@ if [[ $# -gt 0 ]]; then
 fi
 
 target="${INPUT_TARGET:?}"
+packages="${INPUT_PACKAGES:-}"
 runner="${INPUT_RUNNER:-}"
 
 host=$(rustc -vV | grep '^host:' | cut -d' ' -f2)
@@ -354,7 +355,7 @@ register_binfmt() {
 }
 
 setup_linux_host() {
-    apt_packages=()
+    apt_packages=($packages)
     if [[ "${host}" == "${target}" ]]; then
         # TODO: can we reduce the setup time by providing an option to skip installing packages for C++?
         # TODO: other lang? https://packages.ubuntu.com/search?lang=en&suite=jammy&arch=any&searchon=names&keywords=12-aarch64-linux-gnu

--- a/main.sh
+++ b/main.sh
@@ -360,7 +360,7 @@ setup_linux_host() {
         if [[ -n "${REPLY}" ]]; then
             apt_packages+=("${REPLY}")
         fi
-    done <<<"${packages// /,},"
+    done <<<"${packages//[$' \t\n']/,},"
     if [[ "${host}" == "${target}" ]]; then
         # TODO: can we reduce the setup time by providing an option to skip installing packages for C++?
         # TODO: other lang? https://packages.ubuntu.com/search?lang=en&suite=jammy&arch=any&searchon=names&keywords=12-aarch64-linux-gnu

--- a/main.sh
+++ b/main.sh
@@ -355,7 +355,8 @@ register_binfmt() {
 }
 
 setup_linux_host() {
-    apt_packages=($packages)
+    apt_packages=()
+    IFS=" " read -r -a apt_packages <<<"${packages}"
     if [[ "${host}" == "${target}" ]]; then
         # TODO: can we reduce the setup time by providing an option to skip installing packages for C++?
         # TODO: other lang? https://packages.ubuntu.com/search?lang=en&suite=jammy&arch=any&searchon=names&keywords=12-aarch64-linux-gnu


### PR DESCRIPTION
fixes https://github.com/taiki-e/setup-cross-toolchain-action/issues/21

Tried to reuse the existing `install_apt_packages` function to install the packages.
I'd like to also support newlines in the `packages` input but i'm not sure what would be the best way to handle those.

This will need to be added to the changelog and the readme.