### PR TITLE
Support aarch64/armv7hf linux-gnu targets on new GitHub-hosted AArch64 Linux runners

### DIFF
--- a/.github/.cspell/project-dictionary.txt
+++ b/.github/.cspell/project-dictionary.txt
@@ -2,13 +2,14 @@ armeabi
 binfmt
 CXXSTDLIB
 distro
-futex
 haswell
 libclang
 libstdc
 Loongson
 multilib
 neoverse
+powerpcspe
+unikraft
 Vger
 wasmtime
 WINEBOOT

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,166 +45,198 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # https://github.com/taiki-e/rust-cross-toolchain/blob/HEAD/tools/target-list-shared.sh
-        target:
+        # See also https://github.com/taiki-e/rust-cross-toolchain/blob/HEAD/tools/target-list-shared.sh
+        # prettier-ignore
+        include:
           # Linux (GNU)
           # rustup target list | grep -F -e '-linux-gnu'
           # rustc --print target-list | grep -F -e '-linux-gnu'
-          - aarch64-unknown-linux-gnu
-          # - aarch64-unknown-linux-gnu_ilp32 # tier3
+          - { target: aarch64-unknown-linux-gnu, os: ubuntu-22.04 }
+          - { target: aarch64-unknown-linux-gnu, os: ubuntu-22.04-arm }
+          - { target: aarch64-unknown-linux-gnu, os: ubuntu-24.04 }
+          - { target: aarch64-unknown-linux-gnu, os: ubuntu-24.04-arm }
+          # - { target: aarch64-unknown-linux-gnu_ilp32, os: ubuntu-22.04 } # tier3
+          # - { target: aarch64-unknown-linux-gnu_ilp32, os: ubuntu-24.04 } # tier3
           # TODO: https://github.com/BurntSushi/memchr/pull/162
-          # - aarch64_be-unknown-linux-gnu # tier3
-          # - aarch64_be-unknown-linux-gnu_ilp32 # tier3
-          - arm-unknown-linux-gnueabi
-          # - arm-unknown-linux-gnueabihf # supported in rust-cross-toolchain but not ported to this action
-          - armeb-unknown-linux-gnueabi # tier3
-          # - armv4t-unknown-linux-gnueabi # tier3, rustc generate code for armv5t (probably needs to pass +v4t to llvm)
-          - armv5te-unknown-linux-gnueabi
-          - armv7-unknown-linux-gnueabi
-          - armv7-unknown-linux-gnueabihf
-          - i586-unknown-linux-gnu
-          - i686-unknown-linux-gnu
-          - loongarch64-unknown-linux-gnu
-          # - m68k-unknown-linux-gnu # tier3, build fail: https://github.com/rust-lang/rust/issues/89498
-          - mips-unknown-linux-gnu # tier3
-          - mips64-unknown-linux-gnuabi64 # tier3
-          - mips64el-unknown-linux-gnuabi64 # tier3
-          - mipsel-unknown-linux-gnu # tier3
-          - mipsisa32r6-unknown-linux-gnu # tier3
-          - mipsisa32r6el-unknown-linux-gnu # tier3
-          - mipsisa64r6-unknown-linux-gnuabi64 # tier3
-          - mipsisa64r6el-unknown-linux-gnuabi64 # tier3
-          - powerpc-unknown-linux-gnu
-          # - powerpc-unknown-linux-gnuspe # tier3, fails to run test, and GCC 9 removed support for this target
-          - powerpc64-unknown-linux-gnu
-          - powerpc64le-unknown-linux-gnu
-          - riscv32gc-unknown-linux-gnu # tier3
-          - riscv64gc-unknown-linux-gnu
-          - s390x-unknown-linux-gnu
+          # - { target: aarch64_be-unknown-linux-gnu, os: ubuntu-22.04 } # tier3
+          # # - { target: aarch64_be-unknown-linux-gnu, os: ubuntu-24.04 } # tier3 # Segmentation fault on ubuntu 24.04: https://github.com/taiki-e/setup-cross-toolchain-action/issues/1
+          # - { target: aarch64_be-unknown-linux-gnu_ilp32, os: ubuntu-22.04 } # tier3
+          # - { target: aarch64_be-unknown-linux-gnu_ilp32, os: ubuntu-24.04 } # tier3
+          - { target: arm-unknown-linux-gnueabi, os: ubuntu-22.04 }
+          - { target: arm-unknown-linux-gnueabi, os: ubuntu-24.04 }
+          # - { target: arm-unknown-linux-gnueabihf, os: ubuntu-22.04 } # supported in rust-cross-toolchain but not ported to this action
+          # - { target: arm-unknown-linux-gnueabihf, os: ubuntu-24.04 } # supported in rust-cross-toolchain but not ported to this action
+          - { target: armeb-unknown-linux-gnueabi, os: ubuntu-22.04 } # tier3
+          # - { target: armeb-unknown-linux-gnueabi, os: ubuntu-24.04 } # tier3, Segmentation fault on ubuntu 24.04: https://github.com/taiki-e/setup-cross-toolchain-action/issues/1
+          # - { target: armv4t-unknown-linux-gnueabi, os: ubuntu-22.04 } # tier3
+          # - { target: armv4t-unknown-linux-gnueabi, os: ubuntu-24.04 } # tier3
+          - { target: armv5te-unknown-linux-gnueabi, os: ubuntu-22.04 }
+          - { target: armv5te-unknown-linux-gnueabi, os: ubuntu-24.04 }
+          - { target: armv7-unknown-linux-gnueabi, os: ubuntu-22.04 }
+          - { target: armv7-unknown-linux-gnueabi, os: ubuntu-24.04 }
+          - { target: armv7-unknown-linux-gnueabihf, os: ubuntu-22.04 }
+          - { target: armv7-unknown-linux-gnueabihf, os: ubuntu-22.04-arm }
+          - { target: armv7-unknown-linux-gnueabihf, os: ubuntu-24.04 }
+          - { target: armv7-unknown-linux-gnueabihf, os: ubuntu-24.04-arm }
+          - { target: i586-unknown-linux-gnu, os: ubuntu-22.04 }
+          - { target: i586-unknown-linux-gnu, os: ubuntu-24.04 }
+          - { target: i686-unknown-linux-gnu, os: ubuntu-22.04 }
+          - { target: i686-unknown-linux-gnu, os: ubuntu-24.04 }
+          - { target: loongarch64-unknown-linux-gnu, os: ubuntu-22.04 }
+          - { target: loongarch64-unknown-linux-gnu, os: ubuntu-24.04 }
+          # - { target: m68k-unknown-linux-gnu, os: ubuntu-22.04 } # tier3, build fail: https://github.com/rust-lang/rust/issues/89498
+          # - { target: m68k-unknown-linux-gnu, os: ubuntu-24.04 } # tier3, build fail: https://github.com/rust-lang/rust/issues/89498
+          - { target: mips-unknown-linux-gnu, os: ubuntu-22.04 } # tier3
+          - { target: mips-unknown-linux-gnu, os: ubuntu-24.04 } # tier3
+          - { target: mips64-unknown-linux-gnuabi64, os: ubuntu-22.04 } # tier3
+          - { target: mips64-unknown-linux-gnuabi64, os: ubuntu-24.04 } # tier3
+          - { target: mips64el-unknown-linux-gnuabi64, os: ubuntu-22.04 } # tier3
+          - { target: mips64el-unknown-linux-gnuabi64, os: ubuntu-24.04 } # tier3
+          - { target: mipsel-unknown-linux-gnu, os: ubuntu-22.04 } # tier3
+          - { target: mipsel-unknown-linux-gnu, os: ubuntu-24.04 } # tier3
+          - { target: mipsisa32r6-unknown-linux-gnu, os: ubuntu-22.04 } # tier3
+          - { target: mipsisa32r6-unknown-linux-gnu, os: ubuntu-24.04 } # tier3
+          - { target: mipsisa32r6el-unknown-linux-gnu, os: ubuntu-22.04 } # tier3
+          - { target: mipsisa32r6el-unknown-linux-gnu, os: ubuntu-24.04 } # tier3
+          - { target: mipsisa64r6-unknown-linux-gnuabi64, os: ubuntu-22.04 } # tier3
+          - { target: mipsisa64r6-unknown-linux-gnuabi64, os: ubuntu-24.04 } # tier3
+          - { target: mipsisa64r6el-unknown-linux-gnuabi64, os: ubuntu-22.04 } # tier3
+          - { target: mipsisa64r6el-unknown-linux-gnuabi64, os: ubuntu-24.04 } # tier3
+          - { target: powerpc-unknown-linux-gnu, os: ubuntu-22.04 }
+          - { target: powerpc-unknown-linux-gnu, os: ubuntu-24.04 }
+          # - { target: powerpc-unknown-linux-gnuspe, os: ubuntu-22.04 } # tier3, fails to run test, and GCC 9 removed support for this target
+          # - { target: powerpc-unknown-linux-gnuspe, os: ubuntu-24.04 } # tier3, fails to run test, and GCC 9 removed support for this target
+          - { target: powerpc64-unknown-linux-gnu, os: ubuntu-22.04 }
+          - { target: powerpc64-unknown-linux-gnu, os: ubuntu-24.04 }
+          - { target: powerpc64le-unknown-linux-gnu, os: ubuntu-22.04 }
+          - { target: powerpc64le-unknown-linux-gnu, os: ubuntu-24.04 }
+          - { target: riscv32gc-unknown-linux-gnu, os: ubuntu-22.04 } # tier3
+          - { target: riscv32gc-unknown-linux-gnu, os: ubuntu-24.04 } # tier3
+          - { target: riscv64gc-unknown-linux-gnu, os: ubuntu-22.04 }
+          - { target: riscv64gc-unknown-linux-gnu, os: ubuntu-24.04 }
+          - { target: s390x-unknown-linux-gnu, os: ubuntu-22.04 }
+          - { target: s390x-unknown-linux-gnu, os: ubuntu-24.04 }
           # TODO: relocations in generic ELF (EM: 18)
-          # - sparc-unknown-linux-gnu # tier3
-          - sparc64-unknown-linux-gnu
-          - thumbv7neon-unknown-linux-gnueabihf
-          - x86_64-unknown-linux-gnu
-          # - x86_64-unknown-linux-gnux32 # tier3, run-fail
-        os:
-          - ubuntu-22.04
-          - ubuntu-24.04
-        include:
+          # - { target: sparc-unknown-linux-gnu, os: ubuntu-22.04 } # tier3
+          # - { target: sparc-unknown-linux-gnu, os: ubuntu-24.04 } # tier3
+          - { target: sparc64-unknown-linux-gnu, os: ubuntu-22.04 }
+          - { target: sparc64-unknown-linux-gnu, os: ubuntu-24.04 }
+          - { target: thumbv7neon-unknown-linux-gnueabihf, os: ubuntu-22.04 }
+          - { target: thumbv7neon-unknown-linux-gnueabihf, os: ubuntu-22.04-arm }
+          - { target: thumbv7neon-unknown-linux-gnueabihf, os: ubuntu-24.04 }
+          - { target: thumbv7neon-unknown-linux-gnueabihf, os: ubuntu-24.04-arm }
+          - { target: x86_64-unknown-linux-gnu, os: ubuntu-22.04 }
+          - { target: x86_64-unknown-linux-gnu, os: ubuntu-24.04 }
+          # - { target: x86_64-unknown-linux-gnux32, os: ubuntu-22.04 }
+          # - { target: x86_64-unknown-linux-gnux32, os: ubuntu-24.04 }
+
           # Linux (musl)
           # rustup target list | grep -F -e '-linux-musl'
           # rustc --print target-list | grep -F -e '-linux-musl'
-          - target: aarch64-unknown-linux-musl
-          - target: aarch64-unknown-linux-musl
-            runner: qemu-user@7.2
-          - target: aarch64-unknown-linux-musl
-            qemu: '7.2'
-          - target: arm-unknown-linux-musleabi
-          - target: arm-unknown-linux-musleabihf
-          - target: armv5te-unknown-linux-musleabi
-          - target: armv7-unknown-linux-musleabi
-          - target: armv7-unknown-linux-musleabihf
-          # - target: hexagon-unknown-linux-musl # tier3
-          - target: i586-unknown-linux-musl
-          - target: i686-unknown-linux-musl
-          # - target: mips-unknown-linux-musl # tier3
-          # - target: mips64-openwrt-linux-musl # tier3
-          # - target: mips64-unknown-linux-muslabi64 # tier3
-          # - target: mips64el-unknown-linux-muslabi64 # tier3
-          # - target: mipsel-unknown-linux-musl # tier3
-          # - target: powerpc-unknown-linux-musl # tier3
-          # - target: powerpc64-unknown-linux-musl # tier3
-          # - target: powerpc64le-unknown-linux-musl # tier3
-          # - target: riscv32gc-unknown-linux-musl # tier3
-          # - target: riscv64gc-unknown-linux-musl # tier3
-          # - target: s390x-unknown-linux-musl # tier3
-          # - target: thumbv7neon-unknown-linux-musleabihf # tier3
-          - target: x86_64-unknown-linux-musl
+          - { target: aarch64-unknown-linux-musl }
+          - { target: aarch64-unknown-linux-musl, runner: qemu-user@7.2 }
+          - { target: aarch64-unknown-linux-musl, qemu: '7.2' }
+          - { target: arm-unknown-linux-musleabi }
+          - { target: arm-unknown-linux-musleabihf }
+          - { target: armv5te-unknown-linux-musleabi }
+          - { target: armv7-unknown-linux-musleabi }
+          - { target: armv7-unknown-linux-musleabihf }
+          # - { target: hexagon-unknown-linux-musl } # tier3
+          - { target: i586-unknown-linux-musl }
+          - { target: i686-unknown-linux-musl }
+          # - { target: loongarch64-unknown-linux-musl }
+          # - { target: mips-unknown-linux-musl } # tier3
+          # - { target: mips64-openwrt-linux-musl } # tier3
+          # - { target: mips64-unknown-linux-muslabi64 } # tier3
+          # - { target: mips64el-unknown-linux-muslabi64 } # tier3
+          # - { target: mipsel-unknown-linux-musl } # tier3
+          # - { target: powerpc-unknown-linux-musl } # tier3
+          # - { target: powerpc-unknown-linux-muslspe } # tier3
+          # - { target: powerpc64-unknown-linux-musl } # tier3
+          - { target: powerpc64le-unknown-linux-musl }
+          # - { target: riscv32gc-unknown-linux-musl } # tier3
+          - { target: riscv64gc-unknown-linux-musl }
+          # - { target: s390x-unknown-linux-musl } # tier3
+          # - { target: thumbv7neon-unknown-linux-musleabihf } # tier3
+          # - { target: x86_64-unikraft-linux-musl } # tier3
+          - { target: x86_64-unknown-linux-musl }
 
           # Linux (uClibc)
           # rustc --print target-list | grep -F -e '-linux-uclibc'
           # TODO: https://github.com/rust-lang/rust/issues/118190
-          # - target: armv5te-unknown-linux-uclibceabi # tier3
-          # - target: armv7-unknown-linux-uclibceabi # tier3
-          # - target: armv7-unknown-linux-uclibceabihf # tier3
-          # - target: mips-unknown-linux-uclibc # tier3
-          # - target: mipsel-unknown-linux-uclibc # tier3
+          # - { target: armv5te-unknown-linux-uclibceabi } # tier3
+          # - { target: armv7-unknown-linux-uclibceabi } # tier3
+          # - { target: armv7-unknown-linux-uclibceabihf } # tier3
+          # - { target: mips-unknown-linux-uclibc } # tier3
+          # - { target: mipsel-unknown-linux-uclibc } # tier3
 
           # Android
           # rustup target list | grep -F -e '-android'
           # rustc --print target-list | grep -F -e '-android'
-          - target: aarch64-linux-android
-          - target: arm-linux-androideabi
-          - target: arm-linux-androideabi@21
-          - target: armv7-linux-androideabi
-          - target: i686-linux-android
-          - target: thumbv7neon-linux-androideabi
-          - target: x86_64-linux-android
+          - { target: aarch64-linux-android }
+          - { target: arm-linux-androideabi }
+          - { target: arm-linux-androideabi@21 }
+          - { target: armv7-linux-androideabi }
+          - { target: i686-linux-android }
+          - { target: thumbv7neon-linux-androideabi }
+          - { target: x86_64-linux-android }
 
           # FreeBSD
           # rustup target list | grep -F -e '-freebsd'
           # rustc --print target-list | grep -F -e '-freebsd'
-          - target: aarch64-unknown-freebsd # tier3
-          # - target: armv6-unknown-freebsd # tier3
-          # - target: armv7-unknown-freebsd # tier3
-          - target: i686-unknown-freebsd
-          # - target: powerpc-unknown-freebsd # tier3
-          # - target: powerpc64-unknown-freebsd # tier3
-          # - target: powerpc64le-unknown-freebsd # tier3
-          # - target: riscv64gc-unknown-freebsd # tier3
-          - target: x86_64-unknown-freebsd
-          - target: x86_64-unknown-freebsd@13
+          - { target: aarch64-unknown-freebsd } # tier3
+          # - { target: armv6-unknown-freebsd } # tier3
+          # - { target: armv7-unknown-freebsd } # tier3
+          - { target: i686-unknown-freebsd }
+          # - { target: powerpc-unknown-freebsd } # tier3
+          # - { target: powerpc64-unknown-freebsd } # tier3
+          # - { target: powerpc64le-unknown-freebsd } # tier3
+          # - { target: riscv64gc-unknown-freebsd } # tier3
+          - { target: x86_64-unknown-freebsd }
+          - { target: x86_64-unknown-freebsd@13 }
 
           # NetBSD
           # rustup target list | grep -F -e '-netbsd'
           # rustc --print target-list | grep -F -e '-netbsd'
-          - target: aarch64-unknown-netbsd # tier3
-          # - target: aarch64_be-unknown-netbsd # tier3
-          # - target: armv6-unknown-netbsd-eabihf # tier3
-          # - target: armv7-unknown-netbsd-eabihf # tier3
-          # - target: i686-unknown-netbsd # tier3
-          # - target: powerpc-unknown-netbsd # tier3
-          # - target: riscv64gc-unknown-netbsd # tier3
-          # - target: sparc64-unknown-netbsd # tier3
-          - target: x86_64-unknown-netbsd
-          - target: x86_64-unknown-netbsd@9
+          - { target: aarch64-unknown-netbsd } # tier3
+          # - { target: aarch64_be-unknown-netbsd } # tier3
+          # - { target: armv6-unknown-netbsd-eabihf } # tier3
+          # - { target: armv7-unknown-netbsd-eabihf } # tier3
+          # - { target: i686-unknown-netbsd } # tier3
+          # - { target: powerpc-unknown-netbsd } # tier3
+          # - { target: riscv64gc-unknown-netbsd } # tier3
+          # - { target: sparc64-unknown-netbsd } # tier3
+          - { target: x86_64-unknown-netbsd }
+          - { target: x86_64-unknown-netbsd@9 }
 
           # Illumos
           # rustup target list | grep -F -e '-illumos'
           # rustc --print target-list | grep -F -e '-illumos'
-          # - target: aarch64-unknown-illumos # tier3 (not yet supported)
-          - target: x86_64-unknown-illumos
+          # - { target: aarch64-unknown-illumos } # tier3 (not yet supported)
+          - { target: x86_64-unknown-illumos }
 
           # WASI
           # rustup target list | grep -F -e '-wasi'
           # rustc --print target-list | grep -F -e '-wasi'
-          - target: wasm32-wasip1
-          - target: wasm32-wasip1-threads
-          - target: wasm32-wasip2
+          - { target: wasm32-wasip1 }
+          - { target: wasm32-wasip1-threads }
+          - { target: wasm32-wasip2 }
 
           # macOS
           # rustup target list | grep -F -e '-darwin'
           # rustc --print target-list | grep -F -e '-darwin'
-          - target: aarch64-apple-darwin
-            os: macos-latest # AArch64
-          - target: aarch64-apple-darwin
-            os: macos-13 # x86_64
-          # - target: i686-apple-darwin # tier3
-          #   os: macos-latest
-          - target: x86_64-apple-darwin
-            os: macos-latest # AArch64
-          - target: x86_64-apple-darwin
-            os: macos-13 # x86_64
-          - target: x86_64h-apple-darwin # tier3
-            os: macos-latest
+          - { target: aarch64-apple-darwin, os: macos-latest } # AArch64
+          - { target: aarch64-apple-darwin, os: macos-13 } # x86_64
+          # - { target: i686-apple-darwin, os: macos-latest } # tier3
+          - { target: x86_64-apple-darwin, os: macos-latest } # AArch64
+          - { target: x86_64-apple-darwin, os: macos-13 } # x86_64
+          - { target: x86_64h-apple-darwin, os: macos-latest } # tier3
 
           # Mac Catalyst
           # rustup target list | grep -F -e '-macabi'
           # rustc --print target-list | grep -F -e '-macabi'
-          - target: aarch64-apple-ios-macabi
-            os: macos-latest # AArch64
-          - target: x86_64-apple-ios-macabi
-            os: macos-13 # x86_64
+          - { target: aarch64-apple-ios-macabi, os: macos-latest } # AArch64
+          - { target: x86_64-apple-ios-macabi, os: macos-13 } # x86_64
 
           # Windows (MSVC)
           # rustup target list | grep -F -e '-pc-windows-msvc'
@@ -220,40 +252,23 @@ jobs:
           # rustup target list | grep -F -e '-pc-windows-gnu'
           # rustc --print target-list | grep -F -e '-pc-windows-gnu'
           # Windows host:
-          # - target: i686-pc-windows-gnu
-          #   os: windows-latest
-          - target: x86_64-pc-windows-gnu
-            os: windows-latest
+          # - { target: i686-pc-windows-gnu, os: windows-latest }
+          - { target: x86_64-pc-windows-gnu, os: windows-latest }
           # Linux host:
-          # - target: i686-pc-windows-gnu
-          - target: x86_64-pc-windows-gnu
-            os: ubuntu-24.04
-          - target: x86_64-pc-windows-gnu
-            os: ubuntu-22.04
-          - target: x86_64-pc-windows-gnu
-            runner: wine@9.22
-          - target: x86_64-pc-windows-gnu
-            wine: '9.0.0.0'
-          - target: x86_64-pc-windows-gnullvm
-            os: ubuntu-24.04
-          - target: x86_64-pc-windows-gnullvm
-            os: ubuntu-22.04
-          - target: i686-pc-windows-gnullvm
-            os: ubuntu-24.04
-          - target: i686-pc-windows-gnullvm
-            os: ubuntu-22.04
-          - target: aarch64-pc-windows-gnullvm
-            os: ubuntu-24.04
-          - target: aarch64-pc-windows-gnullvm
-            os: ubuntu-22.04
-        # prettier-ignore
-        exclude:
-          # The futex facility returned an unexpected error code: https://github.com/rust-lang/rust/issues/124920
-          - { target: i586-unknown-linux-gnu, os: ubuntu-24.04 }
-          - { target: i686-unknown-linux-gnu, os: ubuntu-24.04 }
-          # Segmentation fault on ubuntu 24.04: https://github.com/taiki-e/setup-cross-toolchain-action/issues/1
-          - { target: aarch64_be-unknown-linux-gnu, os: ubuntu-24.04 }
-          - { target: armeb-unknown-linux-gnueabi, os: ubuntu-24.04 }
+          # - { target: i686-pc-windows-gnu, os: ubuntu-22.04 }
+          # - { target: i686-pc-windows-gnu, os: ubuntu-24.04 }
+          - { target: x86_64-pc-windows-gnu, os: ubuntu-22.04 }
+          # - { target: x86_64-pc-windows-gnu, os: ubuntu-24.04 } # TODO: flaky
+          - { target: x86_64-pc-windows-gnu, os: ubuntu-24.04, runner: wine@9.22 }
+          # - { target: x86_64-pc-windows-gnu, os: ubuntu-24.04, wine: '9.0.0.0' } # TODO: flaky
+          - { target: x86_64-pc-windows-gnullvm, os: ubuntu-22.04 }
+          - { target: x86_64-pc-windows-gnullvm, os: ubuntu-24.04 }
+          - { target: i686-pc-windows-gnullvm, os: ubuntu-22.04 }
+          - { target: i686-pc-windows-gnullvm, os: ubuntu-24.04 }
+          - { target: aarch64-pc-windows-gnullvm, os: ubuntu-22.04 }
+          # - { target: aarch64-pc-windows-gnullvm, os: ubuntu-22.04-arm } # TODO: docker pull hang
+          - { target: aarch64-pc-windows-gnullvm, os: ubuntu-24.04 }
+          # - { target: aarch64-pc-windows-gnullvm, os: ubuntu-24.04-arm } # TODO: docker pull hang
     runs-on: ${{ matrix.os || 'ubuntu-latest' }}
     timeout-minutes: 60
     steps:
@@ -267,7 +282,18 @@ jobs:
           runner: ${{ matrix.runner }}
           qemu: ${{ matrix.qemu }}
           wine: ${{ matrix.wine }}
-      - run: git clone --depth 1 https://github.com/taiki-e/rust-cross-toolchain.git
+      - run: |
+          retry() {
+            for i in {1..10}; do
+              if "$@"; then
+                return 0
+              else
+                sleep "${i}"
+              fi
+            done
+            "$@"
+          }
+          retry git clone --depth 1 https://github.com/taiki-e/rust-cross-toolchain.git
       - run: tools/ci/test.sh "${{ matrix.target }}" rust-cross-toolchain/docker/test/fixtures/rust
         id: test
       - run: /system/bin/sh -c set
@@ -351,7 +377,18 @@ jobs:
           apt-get -o Acquire::Retries=10 -qq update
           apt-get -o Acquire::Retries=10 -qq -o Dpkg::Use-Pty=0 install -y --no-install-recommends gcc libc6-dev jq make cmake
         if: startsWith(matrix.container, 'ubuntu') || startsWith(matrix.container, 'debian')
-      - run: git clone --depth 1 https://github.com/taiki-e/rust-cross-toolchain.git
+      - run: |
+          retry() {
+            for i in {1..10}; do
+              if "$@"; then
+                return 0
+              else
+                sleep "${i}"
+              fi
+            done
+            "$@"
+          }
+          retry git clone --depth 1 https://github.com/taiki-e/rust-cross-toolchain.git
       - run: tools/ci/test.sh "${{ matrix.target }}" rust-cross-toolchain/docker/test/fixtures/rust
         id: test
       # TODO: we should replace ':' from matrix.container: "Error: The artifact name is not valid"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 ## [Unreleased]
 
+- Support aarch64/armv7hf linux-gnu targets on [new GitHub-hosted AArch64 Linux runners (ubuntu-22.04-arm, ubuntu-24.04-arm)](https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/)
+
+  The following targets are supported and tested for native execution:
+
+  - aarch64-unknown-linux-gnu
+  - armv7-unknown-linux-gnueabihf
+  - thumbv7neon-unknown-linux-gnueabihf
+
+  Other targets may also be work on GitHub-hosted AArch64 Linux runners using QEMU or other runner, but have not yet been tested and support is not guaranteed.
+
+- Allow cross-compile to arbitrary Apple targets from macOS.
+
+  GitHub-provided macOS runners support cross-compile for other targets, so this action just runs `rustup target add` and/or sets some environment variables.
+
 ## [1.26.0] - 2024-12-25
 
 - Support windows-gnu/windows-gnullvm targets on ubuntu-24.04.

--- a/README.md
+++ b/README.md
@@ -190,34 +190,34 @@ jobs:
 
 | target | host | runner | note |
 | ------ | ---- | ------ | ---- |
-| `aarch64-unknown-linux-gnu`            | Ubuntu (18.04, 20.04, 22.04, 24.04), Debian (10, 11, 12) [1] | qemu-user                   |       |
-| `aarch64_be-unknown-linux-gnu`         | Ubuntu (18.04,        22.04),        Debian (10, 11, 12) [2] | qemu-user                   | tier3 |
-| `arm-unknown-linux-gnueabi`            | Ubuntu (18.04, 20.04, 22.04, 24.04), Debian (10, 11, 12) [1] | qemu-user                   |       |
-| `armeb-unknown-linux-gnueabi`          | Ubuntu (18.04,        22.04),        Debian (10, 11, 12) [3] | qemu-user                   | tier3 |
-| `armv5te-unknown-linux-gnueabi`        | Ubuntu (18.04, 20.04, 22.04, 24.04), Debian (10, 11, 12) [1] | qemu-user                   |       |
-| `armv7-unknown-linux-gnueabi`          | Ubuntu (18.04, 20.04, 22.04, 24.04), Debian (10, 11, 12) [1] | qemu-user                   |       |
-| `armv7-unknown-linux-gnueabihf`        | Ubuntu (18.04, 20.04, 22.04, 24.04), Debian (10, 11, 12) [1] | qemu-user                   |       |
-| `i586-unknown-linux-gnu`               | Ubuntu (18.04, 20.04, 22.04, 24.04) [1]                      | qemu-user (default), native | [7]   |
-| `i686-unknown-linux-gnu`               | Ubuntu (18.04, 20.04, 22.04, 24.04) [1]                      | native (default), qemu-user | [7]   |
-| `loongarch64-unknown-linux-gnu`        | Ubuntu (18.04, 20.04, 22.04, 24.04), Debian (10, 11, 12) [4] | qemu-user                   | experimental |
-| `mips-unknown-linux-gnu`               | Ubuntu (18.04,        22.04, 24.04), Debian (10, 11, 12) [1] | qemu-user                   | tier3 [6] |
-| `mips64-unknown-linux-gnuabi64`        | Ubuntu (18.04,        22.04, 24.04), Debian (10, 11, 12) [1] | qemu-user                   | tier3 |
-| `mips64el-unknown-linux-gnuabi64`      | Ubuntu (18.04, 20.04, 22.04, 24.04), Debian (10, 11, 12) [1] | qemu-user                   | tier3 |
-| `mipsel-unknown-linux-gnu`             | Ubuntu (18.04, 20.04, 22.04, 24.04), Debian (10, 11, 12) [1] | qemu-user                   | tier3 [6] |
-| `mipsisa32r6-unknown-linux-gnu`        | Ubuntu               (22.04, 24.04), Debian (10, 11, 12) [1] | qemu-user                   | tier3 |
-| `mipsisa32r6el-unknown-linux-gnu`      | Ubuntu        (20.04, 22.04, 24.04), Debian (10, 11, 12) [1] | qemu-user                   | tier3 |
-| `mipsisa64r6-unknown-linux-gnuabi64`   | Ubuntu               (22.04, 24.04), Debian (10, 11, 12) [1] | qemu-user                   | tier3 |
-| `mipsisa64r6el-unknown-linux-gnuabi64` | Ubuntu        (20.04, 22.04, 24.04), Debian (10, 11, 12) [1] | qemu-user                   | tier3 |
-| `powerpc-unknown-linux-gnu`            | Ubuntu (18.04, 20.04, 22.04, 24.04), Debian (10, 11, 12) [1] | qemu-user                   |       |
-| `powerpc64-unknown-linux-gnu`          | Ubuntu (18.04,        22.04, 24.04), Debian (10, 11, 12) [1] | qemu-user                   |       |
-| `powerpc64le-unknown-linux-gnu`        | Ubuntu (18.04, 20.04, 22.04, 24.04), Debian (10, 11, 12) [1] | qemu-user                   |       |
-| `riscv32gc-unknown-linux-gnu`          | Ubuntu (18.04, 20.04, 22.04, 24.04), Debian (10, 11, 12) [5] | qemu-user                   |       |
-| `riscv64gc-unknown-linux-gnu`          | ubuntu (18.04,        22.04, 24.04), Debian (10, 11, 12) [1] | qemu-user                   |       |
-| `s390x-unknown-linux-gnu`              | Ubuntu (18.04, 20.04, 22.04, 24.04), Debian (10, 11, 12) [1] | qemu-user                   |       |
-| `sparc-unknown-linux-gnu`              | Ubuntu (18.04,        22.04, 24.04), Debian (10,     12) [1] | qemu-user                   | tier3, experimental |
-| `sparc64-unknown-linux-gnu`            | Ubuntu (18.04,        22.04, 24.04), Debian (10, 11, 12) [1] | qemu-user                   |       |
-| `thumbv7neon-unknown-linux-gnueabihf`  | Ubuntu (18.04, 20.04, 22.04, 24.04), Debian (10, 11, 12) [1] | qemu-user                   |       |
-| `x86_64-unknown-linux-gnu`             | Ubuntu (18.04, 20.04, 22.04, 24.04), Debian (10, 11, 12) [1] | native (default), qemu-user |       |
+| `aarch64-unknown-linux-gnu`            | Ubuntu (18.04, 20.04, 22.04, 24.04), Debian (10, 11, 12) [1] | native (default, aarch64 host only), qemu-user |       |
+| `aarch64_be-unknown-linux-gnu`         | Ubuntu (18.04,        22.04),        Debian (10, 11, 12) [2] | qemu-user | tier3 |
+| `arm-unknown-linux-gnueabi`            | Ubuntu (18.04, 20.04, 22.04, 24.04), Debian (10, 11, 12) [1] | qemu-user |       |
+| `armeb-unknown-linux-gnueabi`          | Ubuntu (18.04,        22.04),        Debian (10, 11, 12) [3] | qemu-user | tier3 |
+| `armv5te-unknown-linux-gnueabi`        | Ubuntu (18.04, 20.04, 22.04, 24.04), Debian (10, 11, 12) [1] | qemu-user |       |
+| `armv7-unknown-linux-gnueabi`          | Ubuntu (18.04, 20.04, 22.04, 24.04), Debian (10, 11, 12) [1] | qemu-user |       |
+| `armv7-unknown-linux-gnueabihf`        | Ubuntu (18.04, 20.04, 22.04, 24.04), Debian (10, 11, 12) [1] | native (default, aarch64 host only), qemu-user |       |
+| `i586-unknown-linux-gnu`               | Ubuntu (18.04, 20.04, 22.04, 24.04) [1]                      | native (x86_64 host only), qemu-user (default) | [7]   |
+| `i686-unknown-linux-gnu`               | Ubuntu (18.04, 20.04, 22.04, 24.04) [1]                      | native (default, x86_64 host only), qemu-user  | [7]   |
+| `loongarch64-unknown-linux-gnu`        | Ubuntu (18.04, 20.04, 22.04, 24.04), Debian (10, 11, 12) [4] | qemu-user | experimental |
+| `mips-unknown-linux-gnu`               | Ubuntu (18.04,        22.04, 24.04), Debian (10, 11, 12) [1] | qemu-user | tier3 [6] |
+| `mips64-unknown-linux-gnuabi64`        | Ubuntu (18.04,        22.04, 24.04), Debian (10, 11, 12) [1] | qemu-user | tier3 |
+| `mips64el-unknown-linux-gnuabi64`      | Ubuntu (18.04, 20.04, 22.04, 24.04), Debian (10, 11, 12) [1] | qemu-user | tier3 |
+| `mipsel-unknown-linux-gnu`             | Ubuntu (18.04, 20.04, 22.04, 24.04), Debian (10, 11, 12) [1] | qemu-user | tier3 [6] |
+| `mipsisa32r6-unknown-linux-gnu`        | Ubuntu               (22.04, 24.04), Debian (10, 11, 12) [1] | qemu-user | tier3 |
+| `mipsisa32r6el-unknown-linux-gnu`      | Ubuntu        (20.04, 22.04, 24.04), Debian (10, 11, 12) [1] | qemu-user | tier3 |
+| `mipsisa64r6-unknown-linux-gnuabi64`   | Ubuntu               (22.04, 24.04), Debian (10, 11, 12) [1] | qemu-user | tier3 |
+| `mipsisa64r6el-unknown-linux-gnuabi64` | Ubuntu        (20.04, 22.04, 24.04), Debian (10, 11, 12) [1] | qemu-user | tier3 |
+| `powerpc-unknown-linux-gnu`            | Ubuntu (18.04, 20.04, 22.04, 24.04), Debian (10, 11, 12) [1] | qemu-user |       |
+| `powerpc64-unknown-linux-gnu`          | Ubuntu (18.04,        22.04, 24.04), Debian (10, 11, 12) [1] | qemu-user |       |
+| `powerpc64le-unknown-linux-gnu`        | Ubuntu (18.04, 20.04, 22.04, 24.04), Debian (10, 11, 12) [1] | qemu-user |       |
+| `riscv32gc-unknown-linux-gnu`          | Ubuntu (18.04, 20.04, 22.04, 24.04), Debian (10, 11, 12) [5] | qemu-user |       |
+| `riscv64gc-unknown-linux-gnu`          | ubuntu (18.04,        22.04, 24.04), Debian (10, 11, 12) [1] | qemu-user |       |
+| `s390x-unknown-linux-gnu`              | Ubuntu (18.04, 20.04, 22.04, 24.04), Debian (10, 11, 12) [1] | qemu-user |       |
+| `sparc-unknown-linux-gnu`              | Ubuntu (18.04,        22.04, 24.04), Debian (10,     12) [1] | qemu-user | tier3, experimental |
+| `sparc64-unknown-linux-gnu`            | Ubuntu (18.04,        22.04, 24.04), Debian (10, 11, 12) [1] | qemu-user |       |
+| `thumbv7neon-unknown-linux-gnueabihf`  | Ubuntu (18.04, 20.04, 22.04, 24.04), Debian (10, 11, 12) [1] | native (default, aarch64 host only), qemu-user |       |
+| `x86_64-unknown-linux-gnu`             | Ubuntu (18.04, 20.04, 22.04, 24.04), Debian (10, 11, 12) [1] | native (default, x86_64 host only), qemu-user  |       |
 
 [1] GCC 7, glibc 2.27 for Ubuntu 18.04. [GCC 9](https://packages.ubuntu.com/en/focal/gcc), [glibc 2.31](https://packages.ubuntu.com/en/focal/libc6-dev) for Ubuntu 20.04. [GCC 11](https://packages.ubuntu.com/en/jammy/gcc), [glibc 2.35](https://packages.ubuntu.com/en/jammy/libc6-dev) for Ubuntu 22.04. [GCC 13](https://packages.ubuntu.com/en/noble/gcc), [glibc 2.39](https://packages.ubuntu.com/en/noble/libc6-dev) for Ubuntu 24.04. [GCC 8](https://packages.debian.org/en/buster/gcc), [glibc 2.28](https://packages.debian.org/en/buster/libc6-dev) for Debian 10. [GCC 10](https://packages.debian.org/en/bullseye/gcc), [glibc 2.31](https://packages.debian.org/en/bullseye/libc6-dev) for Debian 11. [GCC 12](https://packages.debian.org/en/bookworm/gcc), [glibc 2.36](https://packages.debian.org/en/bookworm/libc6-dev) for Debian 12.<br>
 [2] GCC 10, glibc 2.31<br>

--- a/tools/ci/test.sh
+++ b/tools/ci/test.sh
@@ -33,8 +33,8 @@ esac
 skip_run() {
   case "${target}" in
     # x86_64h-apple-darwin is also x86_64 but build-only due to the CPU of GitHub-provided macOS runners is older than haswell.
-    *-freebsd* | *-netbsd* | *-illumos* | x86_64h-apple-darwin | aarch64*-windows-msvc | arm64*-windows-msvc) return 0 ;;
-    aarch64*-darwin* | arm64*-darwin*)
+    *-freebsd* | *-netbsd* | *-illumos* | x86_64h-apple-darwin) return 0 ;;
+    aarch64*-darwin* | arm64*-darwin* | aarch64*-windows-msvc | arm64*-windows-msvc)
       case "$(uname -m)" in
         aarch64 | arm64) ;;
         *) return 0 ;;
@@ -44,7 +44,7 @@ skip_run() {
   case "$(uname -m)" in
     aarch64 | arm64)
       case "${target}" in
-        aarch64* | arm64* | *-darwin* | *-windows*) return 1 ;;
+        aarch64* | arm64* | arm*hf | thumb*hf | *-darwin* | *-windows*) return 1 ;;
       esac
       ;;
     *)


### PR DESCRIPTION
Support aarch64/armv7hf linux-gnu targets on [new GitHub-hosted AArch64 Linux runners (ubuntu-22.04-arm, ubuntu-24.04-arm)](https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/)

  The following targets are supported and tested for native execution:

  - aarch64-unknown-linux-gnu
  - armv7-unknown-linux-gnueabihf
  - thumbv7neon-unknown-linux-gnueabihf

  Other targets may also be work on GitHub-hosted AArch64 Linux runners using QEMU or other runner, but have not yet been tested and support is not guaranteed.