### PR TITLE
Set PKG_CONFIG_SYSROOT_DIR

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -472,6 +472,7 @@ RANLIB_${target_lower}=${apt_target}-ranlib
 STRIP=${apt_target}-strip
 OBJDUMP=${apt_target}-objdump
 PKG_CONFIG_PATH=/usr/lib/${apt_target}/pkgconfig:${PKG_CONFIG_PATH:-}
+PKG_CONFIG_SYSROOT=/
 EOF
             ;;
         esac

--- a/main.sh
+++ b/main.sh
@@ -472,7 +472,7 @@ RANLIB_${target_lower}=${apt_target}-ranlib
 STRIP=${apt_target}-strip
 OBJDUMP=${apt_target}-objdump
 PKG_CONFIG_PATH=/usr/lib/${apt_target}/pkgconfig:${PKG_CONFIG_PATH:-}
-PKG_CONFIG_SYSROOT=/
+PKG_CONFIG_SYSROOT=${sysroot_dir}
 EOF
             ;;
         esac


### PR DESCRIPTION
This change sets `PKG_CONFIG_SYSROOT` to `/` to improve compatibility when cross-compiling on GitHub-hosted Linux runners (`ubuntu-24.04`):

The following targets benefit from this change and are tested:
- aarch64-unknown-linux-gnu
- i686-unknown-linux-gnu

Relevant diff:

```diff
PKG_CONFIG_PATH=/usr/lib/${apt_target}/pkgconfig:${PKG_CONFIG_PATH:-}
+ PKG_CONFIG_SYSROOT=/
```