### PR TITLE
Add package input option

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,8 +53,8 @@ jobs:
           # rustc --print target-list | grep -F -e '-linux-gnu'
           - { target: aarch64-unknown-linux-gnu, os: ubuntu-22.04 }
           - { target: aarch64-unknown-linux-gnu, os: ubuntu-22.04-arm }
-          - { target: aarch64-unknown-linux-gnu, os: ubuntu-24.04 }
-          - { target: aarch64-unknown-linux-gnu, os: ubuntu-24.04-arm }
+          - { target: aarch64-unknown-linux-gnu, os: ubuntu-24.04, package: libc6-dbg } # arm64
+          - { target: aarch64-unknown-linux-gnu, os: ubuntu-24.04-arm, package: libc6-dbg } # arm64
           # - { target: aarch64-unknown-linux-gnu_ilp32, os: ubuntu-22.04 } # tier3
           # - { target: aarch64-unknown-linux-gnu_ilp32, os: ubuntu-24.04 } # tier3
           - { target: aarch64_be-unknown-linux-gnu, os: ubuntu-22.04 } # tier3
@@ -75,16 +75,16 @@ jobs:
           - { target: armv7-unknown-linux-gnueabi, os: ubuntu-24.04 }
           - { target: armv7-unknown-linux-gnueabihf, os: ubuntu-22.04 }
           - { target: armv7-unknown-linux-gnueabihf, os: ubuntu-22.04-arm }
-          - { target: armv7-unknown-linux-gnueabihf, os: ubuntu-24.04 }
-          - { target: armv7-unknown-linux-gnueabihf, os: ubuntu-24.04-arm }
+          - { target: armv7-unknown-linux-gnueabihf, os: ubuntu-24.04, package: libc6-dbg } # armhf
+          - { target: armv7-unknown-linux-gnueabihf, os: ubuntu-24.04-arm, package: libc6-dbg } # armhf
           # - { target: csky-unknown-linux-gnuabiv2, os: ubuntu-22.04 } # tier3
           # - { target: csky-unknown-linux-gnuabiv2, os: ubuntu-24.04 } # tier3
           # - { target: csky-unknown-linux-gnuabiv2hf, os: ubuntu-22.04 } # tier3
           # - { target: csky-unknown-linux-gnuabiv2hf, os: ubuntu-24.04 } # tier3
           - { target: i586-unknown-linux-gnu, os: ubuntu-22.04 }
-          - { target: i586-unknown-linux-gnu, os: ubuntu-24.04 }
+          - { target: i586-unknown-linux-gnu, os: ubuntu-24.04, package: libc6-dbg } # i386
           - { target: i686-unknown-linux-gnu, os: ubuntu-22.04 }
-          - { target: i686-unknown-linux-gnu, os: ubuntu-24.04 }
+          - { target: i686-unknown-linux-gnu, os: ubuntu-24.04, package: libc6-dbg } # i386
           - { target: loongarch64-unknown-linux-gnu, os: ubuntu-22.04 }
           - { target: loongarch64-unknown-linux-gnu, os: ubuntu-24.04 }
           # - { target: m68k-unknown-linux-gnu, os: ubuntu-22.04 } # tier3, build fail: https://github.com/rust-lang/rust/issues/89498
@@ -112,15 +112,15 @@ jobs:
           - { target: powerpc64-unknown-linux-gnu, os: ubuntu-22.04 }
           - { target: powerpc64-unknown-linux-gnu, os: ubuntu-24.04 }
           - { target: powerpc64le-unknown-linux-gnu, os: ubuntu-22.04 }
-          - { target: powerpc64le-unknown-linux-gnu, os: ubuntu-24.04 }
+          - { target: powerpc64le-unknown-linux-gnu, os: ubuntu-24.04, package: libc6-dbg } # ppc64el
           - { target: riscv32gc-unknown-linux-gnu, os: ubuntu-22.04 } # tier3
           - { target: riscv32gc-unknown-linux-gnu, os: ubuntu-24.04 } # tier3
           # - { target: riscv64a23-unknown-linux-gnu, os: ubuntu-22.04 } # tier3
           # - { target: riscv64a23-unknown-linux-gnu, os: ubuntu-24.04 } # tier3
           - { target: riscv64gc-unknown-linux-gnu, os: ubuntu-22.04 }
-          - { target: riscv64gc-unknown-linux-gnu, os: ubuntu-24.04 }
+          - { target: riscv64gc-unknown-linux-gnu, os: ubuntu-24.04, package: libc6-dbg } # riscv64
           - { target: s390x-unknown-linux-gnu, os: ubuntu-22.04 }
-          - { target: s390x-unknown-linux-gnu, os: ubuntu-24.04 }
+          - { target: s390x-unknown-linux-gnu, os: ubuntu-24.04, package: libc6-dbg } # s390x
           # TODO: relocations in generic ELF (EM: 18)
           # - { target: sparc-unknown-linux-gnu, os: ubuntu-22.04 } # tier3
           # - { target: sparc-unknown-linux-gnu, os: ubuntu-24.04 } # tier3
@@ -131,7 +131,7 @@ jobs:
           - { target: thumbv7neon-unknown-linux-gnueabihf, os: ubuntu-24.04 }
           - { target: thumbv7neon-unknown-linux-gnueabihf, os: ubuntu-24.04-arm }
           - { target: x86_64-unknown-linux-gnu, os: ubuntu-22.04 }
-          - { target: x86_64-unknown-linux-gnu, os: ubuntu-24.04 }
+          - { target: x86_64-unknown-linux-gnu, os: ubuntu-24.04, package: libc6-dbg } # amd64
           # - { target: x86_64-unknown-linux-gnux32, os: ubuntu-22.04 }
           # - { target: x86_64-unknown-linux-gnux32, os: ubuntu-24.04 }
 
@@ -298,6 +298,7 @@ jobs:
           runner: ${{ matrix.runner }}
           qemu: ${{ matrix.qemu }}
           wine: ${{ matrix.wine }}
+          package: ${{ matrix.package }}
       - run: |
           retry() {
             for i in {1..10}; do
@@ -362,6 +363,11 @@ jobs:
           - wasm32-wasip1
           - x86_64-pc-windows-gnu
           - x86_64-pc-windows-gnullvm
+        # prettier-ignore
+        include:
+          - { container: debian:13-slim, target: armv5te-unknown-linux-gnueabi, package: libc6-dbg } # armel
+          - { container: debian:13-slim, target: arm-unknown-linux-gnueabi, package: libc6-dbg } # armel
+          - { container: debian:13-slim, target: armv7-unknown-linux-gnueabi, package: libc6-dbg } # armel
         # prettier-ignore
         exclude:
           # Toolchains not available on ubuntu 18.04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 ## [Unreleased]
 
+- Add `package` input option to install packages for target. ([#34](https://github.com/taiki-e/setup-cross-toolchain-action/issues/34))
+
+  This is currently only supported for some Linux (GNU) targets on Ubuntu/Debian hosts, and packages will be installed using the form: `<sudo as needed> apt-get install --no-install-recommends <each package>:<target's dpkg arch>...`
+
 ## [1.34.0] - 2025-12-28
 
 - Set default qemu cpu to `max` on AArch64, Arm, LoongArch64, RISC-V, and s390x.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ GitHub Action for setup toolchains for cross compilation and cross testing for R
 | ---- | :------: | ----------- | ---- | ------- |
 | target | **✓** | Target triple | String | |
 | runner | | Test runner (`none` or platform specific runner described in [Platform Support](#platform-support) section) | String | |
+| package | | Packages to install for target (whitespace or comma separated list) \[1] | String | |
+
+\[1]: This is currently only supported for some Linux (GNU) targets on Ubuntu/Debian hosts, and packages will be installed using the form: `<sudo as needed> apt-get install --no-install-recommends <each package>:<target's dpkg arch>...`
 
 ### Example workflow: Basic usage
 

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,9 @@ inputs:
   wine:
     description: Wine version
     required: false
+  package:
+    description: Packages to install for target (whitespace or comma separated list)
+    required: false
 
 # Note:
 # - inputs.* should be manually mapped to INPUT_* due to https://github.com/actions/runner/issues/665
@@ -28,3 +31,4 @@ runs:
         INPUT_RUNNER: ${{ inputs.runner }}
         INPUT_QEMU: ${{ inputs.qemu }}
         INPUT_WINE: ${{ inputs.wine }}
+        INPUT_PACKAGE: ${{ inputs.package }}


### PR DESCRIPTION
This adds `package` input option to install packages for target.

This is currently only supported for some Linux (GNU) targets on Ubuntu/Debian hosts, and packages will be installed using the form: `<sudo as needed> apt-get install --no-install-recommends <each package>:<target's dpkg arch>...`

Closes #21
Replaces #23
cc @tjallingt